### PR TITLE
Add a streaming decoder interface

### DIFF
--- a/open-vcdiff-sys/src/glue.cc
+++ b/open-vcdiff-sys/src/glue.cc
@@ -3,8 +3,122 @@
 #include <string.h>
 #include "google/vcencoder.h"
 #include "google/vcdecoder.h"
+#include "google/output_string.h"
+
+class OutputCallbackInterface : public open_vcdiff::OutputStringInterface {
+public:
+    OutputCallbackInterface(
+        void * pointer,
+        output_callback_append_fn append,
+        output_callback_clear_fn clear,
+        output_callback_reserve_fn reserve,
+        output_callback_size_fn size
+        );
+    virtual ~OutputCallbackInterface();
+    virtual OutputCallbackInterface& append(const char* s, size_t n);
+    virtual void clear();
+    virtual void push_back(char c);
+    virtual void ReserveAdditionalBytes(size_t res_arg);
+    virtual size_t size() const;
+private:
+    void * pointer;
+    output_callback_append_fn append_fn;
+    output_callback_clear_fn clear_fn;
+    output_callback_reserve_fn reserve_fn;
+    output_callback_size_fn size_fn;
+};
+
+OutputCallbackInterface::OutputCallbackInterface(
+    void * pointer,
+    output_callback_append_fn append,
+    output_callback_clear_fn clear,
+    output_callback_reserve_fn reserve,
+    output_callback_size_fn size
+) : pointer(pointer), append_fn(append), clear_fn(clear), reserve_fn(reserve), size_fn(size) {
+}
+
+OutputCallbackInterface::~OutputCallbackInterface() {
+}
+
+OutputCallbackInterface& OutputCallbackInterface::append(const char *s, size_t n) {
+    append_fn(pointer, s, n);
+    return *this;       // like std::string
+}
+
+void OutputCallbackInterface::push_back(char c) {
+    // implement in terms of append
+    append_fn(pointer, &c, 1);
+}
+
+void OutputCallbackInterface::clear() {
+    clear_fn(pointer);
+}
+
+void OutputCallbackInterface::ReserveAdditionalBytes(size_t n) {
+    reserve_fn(pointer, n);
+}
+
+size_t OutputCallbackInterface::size() const {
+    return size_fn(pointer);
+}
+
+
+struct callback_decoder {
+    callback_decoder(OutputCallbackInterface callback_interface);
+
+    open_vcdiff::VCDiffStreamingDecoder decoder;
+    OutputCallbackInterface callback_interface;
+};
+
+callback_decoder::callback_decoder(OutputCallbackInterface callback_interface)
+    : callback_interface(callback_interface)
+{
+}
 
 extern "C" {
+
+void * new_decoder() {
+    return (void *)(new open_vcdiff::VCDiffStreamingDecoder());
+}
+
+void decoder_start_decoding(void *decoder, const char *dictionary_ptr, size_t dictionary_size) {
+    ((open_vcdiff::VCDiffStreamingDecoder *)decoder)->StartDecoding(dictionary_ptr, dictionary_size);
+}
+
+bool decoder_set_maximum_target_file_size(void *decoder, size_t new_maximum_target_file_size) {
+    return ((open_vcdiff::VCDiffStreamingDecoder *)decoder)->SetMaximumTargetFileSize(new_maximum_target_file_size);
+}
+
+bool decoder_set_maximum_target_window_size(void *decoder, size_t new_maximum_target_window_size) {
+    return ((open_vcdiff::VCDiffStreamingDecoder *)decoder)->SetMaximumTargetWindowSize(new_maximum_target_window_size);
+}
+
+void decoder_set_allow_vcd_target(void *decoder, bool allow_vcd_target) {
+    ((open_vcdiff::VCDiffStreamingDecoder *)decoder)->SetAllowVcdTarget(allow_vcd_target);
+}
+
+bool decoder_decode_chunk_to_callbacks(
+    void *decoder, const char *data, size_t len,
+    void *callback_pointer,
+    output_callback_append_fn append_fn,
+    output_callback_clear_fn clear_fn,
+    output_callback_reserve_fn reserve_fn,
+    output_callback_size_fn size_fn
+    )
+{
+    OutputCallbackInterface output(callback_pointer, append_fn, clear_fn, reserve_fn, size_fn);
+    return ((open_vcdiff::VCDiffStreamingDecoder *)decoder)->DecodeChunkToInterface(data, len, &output);
+}
+
+bool decoder_finish_decoding(void *decoder) {
+    return ((open_vcdiff::VCDiffStreamingDecoder *)decoder)->FinishDecoding();
+}
+
+void delete_decoder(void *decoder) {
+    delete ((open_vcdiff::VCDiffStreamingDecoder *)decoder);
+}
+
+
 
 void vcdiff_encode(const uint8_t *dictionary_data,
                    size_t dictionary_len,
@@ -26,26 +140,6 @@ void vcdiff_encode(const uint8_t *dictionary_data,
     *encoded_data = (uint8_t *) malloc(encoded.size());
     memcpy(*encoded_data, encoded.data(), encoded.size());
     *encoded_len = encoded.size();
-}
-
-void vcdiff_decode(const uint8_t *dictionary_data,
-                   size_t dictionary_len,
-                   const uint8_t *encoded_data,
-                   size_t encoded_len,
-                   uint8_t **target_data,
-                   size_t *target_len) {
-    open_vcdiff::VCDiffDecoder decoder;
-    std::string encoded((const char *) encoded_data, encoded_len);
-    std::string target;
-
-    decoder.Decode((const char *) dictionary_data,
-                   dictionary_len,
-                   encoded,
-                   &target);
-
-    *target_data = (uint8_t *) malloc(target.size());
-    memcpy(*target_data, target.data(), target.size());
-    *target_len = target.size();
 }
 
 void vcdiff_free_data(uint8_t *data) {

--- a/open-vcdiff-sys/src/glue.h
+++ b/open-vcdiff-sys/src/glue.h
@@ -28,7 +28,29 @@ enum VCDiffFormatExtensionFlagValues {
     VCD_FORMAT_JSON = 0x04
 };
 
+typedef void (*output_callback_append_fn)(void *, const char *, size_t);
+typedef void (*output_callback_clear_fn)(void *);
+typedef void (*output_callback_reserve_fn)(void *, size_t);
+typedef size_t (*output_callback_size_fn)(const void *);
+
 typedef int VCDiffFormatExtensionFlags;
+
+void * new_decoder();
+void decoder_start_decoding(void *decoder, const char *dictionary_ptr, size_t dictionary_size);
+bool decoder_set_maximum_target_file_size(void *decoder, size_t new_maximum_target_file_size);
+bool decoder_set_maximum_target_window_size(void *decoder, size_t new_maximum_target_window_size);
+void decoder_set_allow_vcd_target(void *decoder, bool allow_vcd_target);
+bool decoder_decode_chunk_to_callbacks(
+    void *decoder, const char *data, size_t len,
+    void * pointer,
+    output_callback_append_fn append_fn,
+    output_callback_clear_fn clear_fn,
+    output_callback_reserve_fn reserve_fn,
+    output_callback_size_fn size_fn
+    );
+bool decoder_finish_decoding(void *decoder);
+void delete_decoder(void *decoder);
+
 
 void vcdiff_encode(const uint8_t *dictionary_data,
                    size_t dictionary_len,
@@ -38,13 +60,6 @@ void vcdiff_encode(const uint8_t *dictionary_data,
                    size_t *encoded_len,
                    VCDiffFormatExtensionFlags flags,
                    bool look_for_target_matches);
-
-void vcdiff_decode(const uint8_t *dictionary_data,
-                   size_t dictionary_len,
-                   const uint8_t *encoded_data,
-                   size_t encoded_len,
-                   uint8_t **target_data,
-                   size_t *target_len);
 
 void vcdiff_free_data(uint8_t *data);
 

--- a/open-vcdiff-sys/src/lib.rs
+++ b/open-vcdiff-sys/src/lib.rs
@@ -55,17 +55,75 @@ pub enum VCDiffFormatExtensionFlagValues {
     VCD_FORMAT_JSON = 4,
 }
 pub type VCDiffFormatExtensionFlags = ::std::os::raw::c_int;
+
+#[repr(C)]
+#[derive(Debug, Copy)]
+pub struct callback_decoder {
+    pub _address: u8,
+}
+impl Clone for callback_decoder {
+    fn clone(&self) -> Self { *self }
+}
+
+pub type output_callback_append_fn =
+::std::option::Option<unsafe extern "C" fn(arg1:
+                                           *mut ::std::os::raw::c_void,
+                                           arg2:
+                                           *const uint8_t,
+                                           arg3: usize)>;
+pub type output_callback_clear_fn =
+::std::option::Option<unsafe extern "C" fn(arg1:
+                                           *mut ::std::os::raw::c_void)>;
+pub type output_callback_reserve_fn =
+::std::option::Option<unsafe extern "C" fn(arg1:
+                                           *mut ::std::os::raw::c_void,
+                                           arg2: usize)>;
+pub type output_callback_size_fn =
+::std::option::Option<unsafe extern "C" fn(arg1:
+                                           *const ::std::os::raw::c_void)
+                                           -> usize>;
+
 extern "C" {
+    pub fn new_decoder() -> *mut ::std::os::raw::c_void;
+    pub fn decoder_start_decoding(decoder: *mut ::std::os::raw::c_void,
+                                  dictionary_ptr:
+                                  *const ::std::os::raw::c_char,
+                                  dictionary_size: usize);
+    pub fn decoder_set_maximum_target_file_size(decoder:
+                                                *mut ::std::os::raw::c_void,
+                                                new_maximum_target_file_size:
+                                                usize) -> bool;
+    pub fn decoder_set_maximum_target_window_size(decoder:
+                                                  *mut ::std::os::raw::c_void,
+                                                  new_maximum_target_window_size:
+                                                  usize) -> bool;
+    pub fn decoder_set_allow_vcd_target(decoder: *mut ::std::os::raw::c_void,
+                                        allow_vcd_target: bool);
+    pub fn decoder_decode_chunk_to_callbacks(decoder:
+                                             *mut ::std::os::raw::c_void,
+                                             data:
+                                             *const ::std::os::raw::c_char,
+                                             len: usize,
+                                             pointer:
+                                             *mut ::std::os::raw::c_void,
+                                             append_fn:
+                                             output_callback_append_fn,
+                                             clear_fn:
+                                             output_callback_clear_fn,
+                                             reserve_fn:
+                                             output_callback_reserve_fn,
+                                             size_fn: output_callback_size_fn)
+                                             -> bool;
+    pub fn decoder_finish_decoding(decoder: *mut ::std::os::raw::c_void)
+                                   -> bool;
+    pub fn delete_decoder(decoder: *mut ::std::os::raw::c_void);
+
     #[link_name = "vcdiff_encode"]
     pub fn encode(dictionary_data: *const uint8_t, dictionary_len: size_t,
                   target_data: *const uint8_t, target_len: size_t,
                   encoded_data: *mut *mut uint8_t, encoded_len: *mut size_t,
                   flags: VCDiffFormatExtensionFlags,
                   look_for_target_matches: u8);
-    #[link_name = "vcdiff_decode"]
-    pub fn decode(dictionary_data: *const uint8_t, dictionary_len: size_t,
-                  encoded_data: *const uint8_t, encoded_len: size_t,
-                  target_data: *mut *mut uint8_t, target_len: *mut size_t);
     #[link_name = "vcdiff_free_data"]
     pub fn free_data(data: *const uint8_t);
 }

--- a/src/streaming.rs
+++ b/src/streaming.rs
@@ -1,0 +1,171 @@
+use ::open_vcdiff_sys;
+
+use std::error;
+use std::fmt;
+use std::marker::PhantomData;
+use std::mem;
+use std::os::raw::c_void;
+use std::slice;
+use std::result;
+
+#[derive(Debug,Copy,Clone,PartialEq,Eq)]
+pub struct Error(&'static str);
+
+impl error::Error for Error {
+    fn description(&self) -> &str {
+        self.0
+    }
+}
+
+impl fmt::Display for Error {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        write!(f, "vcdiff error: {}", self.0)
+    }
+}
+
+pub type Result<T> = result::Result<T,Error>;
+
+pub trait Output {
+    fn append(&mut self, buffer: &[u8]);
+    fn clear(&mut self);
+    fn reserve(&mut self, bytes: usize);
+    fn size(&self) -> usize;
+}
+
+impl Output for Vec<u8> {
+    fn append(&mut self, buffer: &[u8]) {
+        self.extend_from_slice(buffer);
+    }
+
+    fn clear(&mut self) {
+        self.clear();
+    }
+
+    fn reserve(&mut self, bytes: usize) {
+        self.reserve(bytes);
+    }
+
+    fn size(&self) -> usize {
+        self.len()
+    }
+}
+
+// Set up some Rust functions to call from C which delegate to an Output
+
+unsafe extern "C" fn output_trait_append_cb(callback_pointer: *mut c_void, buffer: *const u8, buffer_size: usize) {
+    let mut callback_pointer: Box<&mut Output> = mem::transmute(callback_pointer);
+    let buffer: &[u8] = slice::from_raw_parts(buffer, buffer_size);
+    callback_pointer.append(buffer);
+}
+
+unsafe extern "C" fn output_trait_clear_cb(callback_pointer: *mut c_void) {
+    let mut callback_pointer: Box<&mut Output> = mem::transmute(callback_pointer);
+    callback_pointer.clear();
+}
+
+unsafe extern "C" fn output_trait_reserve_cb(callback_pointer: *mut c_void, bytes: usize) {
+    let mut callback_pointer: Box<&mut Output> = mem::transmute(callback_pointer);
+    callback_pointer.reserve(bytes);
+}
+
+unsafe extern "C" fn output_trait_size_cb(callback_pointer: *const c_void) -> usize {
+    let callback_pointer: Box<&Output> = mem::transmute(callback_pointer);
+    callback_pointer.size()
+}
+
+pub struct Decoder<'d> {
+    decoder: *mut c_void,
+
+    // decoder holds a borrow across the FFI boundary; model this as PhantomData
+    dictionary: PhantomData<&'d [u8]>,
+}
+
+impl<'d> Decoder<'d> {
+    pub fn new(dictionary: &'d [u8]) -> Decoder<'d> {
+        // make a new decoder
+        // this is C++ "operator new" under the hood
+        let decoder = unsafe { open_vcdiff_sys::new_decoder() };
+
+        // point it to the dictionary buffer
+        // this is a borrow we'll keep for the lifetime of the Decoder, so there's no need to copy it
+        unsafe { open_vcdiff_sys::decoder_start_decoding(decoder, dictionary.as_ptr() as *const i8, dictionary.len()) }
+
+        // Decoder is ready to use
+        Decoder{
+            decoder: decoder,
+            dictionary: PhantomData
+        }
+    }
+
+    pub fn set_maximum_target_file_size(&mut self, size: usize) -> Result<()> {
+        if unsafe {
+            open_vcdiff_sys::decoder_set_maximum_target_file_size(self.decoder, size)
+        } {
+            Ok(())
+        } else {
+            Err(Error("unable to set decoder maximum target file size"))
+        }
+    }
+
+    pub fn set_maximum_target_window_size(&mut self, size: usize) -> Result<()> {
+        if unsafe {
+            open_vcdiff_sys::decoder_set_maximum_target_window_size(self.decoder, size)
+        } {
+            Ok(())
+        } else {
+            Err(Error("unable to set decoder maximum target window size"))
+        }
+    }
+
+    pub fn set_allow_vcd_target(&mut self, allow: bool) -> Result<()> {
+        unsafe {
+            open_vcdiff_sys::decoder_set_allow_vcd_target(self.decoder, allow);
+        }
+
+        // for whatever reason, this call can't fail, but all the others can
+        // return a Result anyway for consistency
+        Ok(())
+    }
+
+    pub fn decode<O: Output>(&mut self, data: &[u8], output: &mut O) -> Result<()> {
+        // box the output reference so we can pass it to C and back
+        let boxed_output: Box<&mut Output> = Box::new(output);
+
+        // unsafety: decode_chunk() doesn't hold any pointers outside the scope of the call
+        // we have a borrow of everything we pass in, so there's no lifetime concerns
+        if unsafe {
+            open_vcdiff_sys::decoder_decode_chunk_to_callbacks(
+                self.decoder,
+                data.as_ptr() as *const i8,
+                data.len(),
+                mem::transmute(boxed_output),
+                Some(output_trait_append_cb),
+                Some(output_trait_clear_cb),
+                Some(output_trait_reserve_cb),
+                Some(output_trait_size_cb)
+            )
+        } {
+            Ok(())
+        } else {
+            Err(Error("decode failed"))
+        }
+    }
+
+    pub fn finish(self) -> Result<()> {
+        if unsafe {
+            open_vcdiff_sys::decoder_finish_decoding(self.decoder)
+        } {
+            Ok(())
+        } else {
+            Err(Error("finish decoding failed"))
+        }
+    }
+}
+
+impl<'d> Drop for Decoder<'d> {
+    fn drop(&mut self)
+    {
+        // run C++ "operator delete" on the decoder we hold
+        unsafe { open_vcdiff_sys::delete_decoder(self.decoder); }
+    }
+}


### PR DESCRIPTION
It's a little rough, but here's some code to discuss that addresses #1. This adds a streaming decoder interface that directly mirrors the underlying library, removes the previous C decoding interface, and makes Rust `decode()` use the new streaming interface instead. Tests all pass.

Things I can think of that still need to get done:

* Regenerate the bindings (my version of `bindgen` seems different than yours)
* Document the new types and functions
* Make encoding work in a comparable way
* Test the streaming interface directly, instead of testing just `decode()` to test the streaming interface

I wanted to show you what I have before committing fully to this approach in case you had something else in mind.